### PR TITLE
Update CI to Handle no dev branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -192,7 +192,7 @@ jobs:
       - test
       - code_coverage
       - sbom
-    if: ${{ endsWith(github.base_ref, 'main') && contains(github.head_ref, 'release') }}
+    if: ${{ (endsWith(github.base_ref, 'main') && contains(github.head_ref, 'release')) || ( endsWith(github.base_ref, 'main') && github.event.pull_request.merged ) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -202,11 +202,27 @@ jobs:
       - name: Get RC Version
         id: lasttag
         run: |
+          apt-get install -yqq jq
           COMMIT="${{github.sha}}"
-          V="${{github.head_ref}}"
-          V="${V#release/}"
+          if ${{contains(github.head_ref, 'release')}}; then
+            V="${{github.head_ref}}"
+            V="${V#release/}"
+          else
+            V="$(cargo metadata --format-version=1 --no-deps | jq '.packages[0].version')"
+            V=v${V//\"/} #remove '"'s
+          fi
 
-          if ${{! github.event.pull_request.merged}}; then
+          # Check to see if the version tag already exists
+          # If it does, print a message and exit with an error code
+          if [ $(git tag --list "$V") ]; then
+            echo "Version tag already exists. Did you bump the version number?"
+            exit 1
+          fi
+
+          # Create an RC release if
+          # 1) This PR is a release branch that hasn't been merged to main.
+          # 2) This is a feature branch being merged into the main branch.
+          if ${{(! github.event.pull_request.merged && contains(github.head_ref, 'release')) || (github.event.pull_request.merged && !contains(github.head_ref, 'release'))}}; then
             V="${V}-$(git tag --list ${V}* | wc -l)"
           fi
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -192,7 +192,7 @@ jobs:
       - test
       - code_coverage
       - sbom
-    if: ${{ (endsWith(github.base_ref, 'main') && contains(github.head_ref, 'release')) || ( endsWith(github.base_ref, 'main') && github.event.pull_request.merged ) }}
+    if: ${{ (endsWith(github.base_ref, 'main') && (contains(github.head_ref, 'release/')) || github.event.pull_request.merged ) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -204,7 +204,7 @@ jobs:
         run: |
           apt-get install -yqq jq
           COMMIT="${{github.sha}}"
-          if ${{contains(github.head_ref, 'release')}}; then
+          if ${{contains(github.head_ref, 'release/')}}; then
             V="${{github.head_ref}}"
             V="${V#release/}"
           else
@@ -222,7 +222,7 @@ jobs:
           # Create an RC release if
           # 1) This PR is a release branch that hasn't been merged to main.
           # 2) This is a feature branch being merged into the main branch.
-          if ${{(! github.event.pull_request.merged && contains(github.head_ref, 'release')) || (github.event.pull_request.merged && !contains(github.head_ref, 'release'))}}; then
+          if ${{(! github.event.pull_request.merged && contains(github.head_ref, 'release/')) || (github.event.pull_request.merged && !contains(github.head_ref, 'release/'))}}; then
             V="${V}-$(git tag --list ${V}* | wc -l)"
           fi
 
@@ -261,7 +261,7 @@ jobs:
 
             ${{steps.changelog.outputs.description}}
 
-          prerelease: ${{! github.event.pull_request.merged}}
+          prerelease: ${{ (! github.event.pull_request.merged) || (github.event.pull_request.merged && ! contains(github.head_ref, 'release/')) }}
           commit: ${{steps.lasttag.outputs.commit}}
           makeLatest: true
           tag: ${{steps.lasttag.outputs.version}}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1275,7 +1275,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsp-toolkit-kic-lib"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tsp-toolkit-kic-lib"
 description = "A library specifically enabling communication to the Keithley product-line of instruments"
-version = "0.15.0"
+version = "0.15.1"
 authors = ["Keithley Instruments, LLC"]
 edition = "2021"
 repository = "https://github.com/tektronix/tsp-toolkit-kic-lib"


### PR DESCRIPTION
To simplify the release workflow, the team has decided to remove the `dev` branch. This change requires a few changes to the CI system for all projects.

1. For every feature-branch pull request the is merged to `main`, create an appropriately versioned RC release (a tag, a GitHub release, plus any packaging) with the version indicated by the project's manifest file followed by a `-N`, where `N` is an incrementing number based on the number of RC tags for that release already in existence.
2. If the branch merging into `main` is a release branch, create an RC for every push to that branch with the version indicated by the release branch name followed by a `-N`, where `N` is an incrementing number based on the number of RC tags for that release already in existence.
3. If a pull request is merged to `main` from a release branch, create a full release with the version number indicated in the release branch name.