### PR TITLE
Fixes to ensure getting info doesn't fail when it could work

### DIFF
--- a/src/instrument/info.rs
+++ b/src/instrument/info.rs
@@ -10,6 +10,8 @@ use std::{
 
 use crate::interface::connection_addr::ConnectionAddr;
 
+use super::clear_output_queue;
+
 /// The information about an instrument.
 #[allow(clippy::module_name_repetitions)]
 #[derive(serde::Serialize, Debug, Default, Clone, PartialEq, Eq, Hash)]
@@ -36,6 +38,11 @@ pub struct InstrumentInfo {
 /// - Any error in converting the retrieved IDN string into [`InstrumentInfo`]
 #[allow(clippy::module_name_repetitions)]
 pub fn get_info<T: Read + Write + ?Sized>(rw: &mut T) -> Result<InstrumentInfo> {
+    rw.write_all(b"abort\n")?;
+    std::thread::sleep(Duration::from_millis(100));
+    rw.write_all(b"*CLS\n")?;
+    std::thread::sleep(Duration::from_millis(100));
+    clear_output_queue(rw, 1000, Duration::from_millis(1))?;
     rw.write_all(b"*IDN?\n")?;
     let mut info: Option<InstrumentInfo> = None;
     for _ in 0..100 {

--- a/src/instrument/mod.rs
+++ b/src/instrument/mod.rs
@@ -33,7 +33,7 @@ pub trait Instrument:
 /// # Errors
 /// Whatever can errors can occur with [`std::io::Read`], [`std::io::Write`] or
 /// [`tsp_toolkit_kic_lib::interface::NonBlock`].
-pub fn clear_output_queue<T: Read + Write + NonBlock + ?Sized>(
+pub fn clear_output_queue<T: Read + Write + ?Sized>(
     rw: &mut T,
     max_attempts: usize,
     delay_between_attempts: Duration,
@@ -41,8 +41,6 @@ pub fn clear_output_queue<T: Read + Write + NonBlock + ?Sized>(
     let timestamp = chrono::Utc::now().to_string();
 
     rw.write_all(format!("print(\"{timestamp}\")\n").as_bytes())?;
-
-    rw.set_nonblocking(true)?;
 
     let mut accumulate = String::new();
     for _ in 0..max_attempts {

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -35,20 +35,6 @@ impl NonBlock for TcpStream {
 impl Info for TcpStream {
     // write all methods for Info trait here
     fn info(&mut self) -> Result<InstrumentInfo> {
-        let ip_addr = self.peer_addr();
-        if let Ok(ip_addr) = ip_addr {
-            let ip_addr = ip_addr.ip();
-            let uri = format!("http://{ip_addr}/lxi/identification");
-            let resp = reqwest::blocking::get(uri);
-            if let Ok(response) = resp {
-                if let Ok(txt) = response.text() {
-                    if let Ok(info) = InstrumentInfo::try_from(&txt) {
-                        return Ok(info);
-                    }
-                }
-            }
-        }
-        // if lxi page is not available, then get info from the instrument
         get_info(self)
     }
 }


### PR DESCRIPTION
- remove reqwest fetch of LXI identification page (it was causing panics)
- Call `abort`, `*CLS`, and `clear_instrument_output_queue` before getting info