### PR TITLE
Make Checking Model Support Easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Security -- in case of vulnerabilities.
 -->
 
+## [0.19.0]
+
+### Added
+
+- Added `is_supported` function that takes in a model number
+- Added `model_is` method on `model::**::Instrument` structs
+
 ## [0.18.4]
 
 ### Fixed
@@ -106,7 +113,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Using `read_password` instead of `prompt_password` of rpassword crate (TSP-517)
 
 <!--Version Comparison Links-->
-[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-lib/compare/v0.18.4..HEAD
+[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-lib/compare/v0.19.0..HEAD
+[0.19.0]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.0
 [0.18.4]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.18.4
 [0.18.3]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.18.3
 [0.18.2]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.18.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,7 +1508,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsp-toolkit-kic-lib"
-version = "0.18.4"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tsp-toolkit-kic-lib"
 description = "A library specifically enabling communication to the Keithley product-line of instruments"
-version = "0.18.4"
+version = "0.19.0"
 authors = ["Keithley Instruments, LLC"]
 edition = "2021"
 repository = "https://github.com/tektronix/tsp-toolkit-kic-lib"

--- a/src/model/ki2600.rs
+++ b/src/model/ki2600.rs
@@ -27,9 +27,16 @@ pub struct Instrument {
 impl Instrument {
     #[must_use]
     pub fn is(info: &InstrumentInfo) -> bool {
-        info.model
+        info.model.as_ref().is_some_and(Self::model_is)
+    }
+
+    #[must_use]
+    pub fn model_is(model: impl AsRef<str>) -> bool {
+        model
             .as_ref()
-            .is_some_and(|model| model.split_ascii_whitespace().last().is_some_and(is_2600))
+            .split_ascii_whitespace()
+            .last()
+            .is_some_and(is_2600)
     }
 
     #[must_use]
@@ -50,7 +57,7 @@ impl Instrument {
 //Implement device_interface::Interface since it is a subset of instrument::Instrument trait.
 impl instrument::Instrument for Instrument {}
 
-fn is_2600(model: impl AsRef<str>) -> bool {
+pub fn is_2600(model: impl AsRef<str>) -> bool {
     [
         "2601",
         "2602",

--- a/src/model/ki2600.rs
+++ b/src/model/ki2600.rs
@@ -57,7 +57,7 @@ impl Instrument {
 //Implement device_interface::Interface since it is a subset of instrument::Instrument trait.
 impl instrument::Instrument for Instrument {}
 
-pub fn is_2600(model: impl AsRef<str>) -> bool {
+fn is_2600(model: impl AsRef<str>) -> bool {
     [
         "2601",
         "2602",

--- a/src/model/ki3700.rs
+++ b/src/model/ki3700.rs
@@ -56,7 +56,7 @@ impl Instrument {
 //Implement device_interface::Interface since it is a subset of instrument::Instrument trait.
 impl instrument::Instrument for Instrument {}
 
-pub(crate) fn is_3700(model: impl AsRef<str>) -> bool {
+fn is_3700(model: impl AsRef<str>) -> bool {
     [
         "3706",
         "3706-SNFP",

--- a/src/model/ki3700.rs
+++ b/src/model/ki3700.rs
@@ -26,9 +26,16 @@ pub struct Instrument {
 impl Instrument {
     #[must_use]
     pub fn is(info: &InstrumentInfo) -> bool {
-        info.model
+        info.model.as_ref().is_some_and(Self::model_is)
+    }
+
+    #[must_use]
+    pub fn model_is(model: impl AsRef<str>) -> bool {
+        model
             .as_ref()
-            .is_some_and(|model| model.split_ascii_whitespace().last().is_some_and(is_3700))
+            .split_ascii_whitespace()
+            .last()
+            .is_some_and(is_3700)
     }
 
     #[must_use]
@@ -49,7 +56,7 @@ impl Instrument {
 //Implement device_interface::Interface since it is a subset of instrument::Instrument trait.
 impl instrument::Instrument for Instrument {}
 
-fn is_3700(model: impl AsRef<str>) -> bool {
+pub(crate) fn is_3700(model: impl AsRef<str>) -> bool {
     [
         "3706",
         "3706-SNFP",

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -11,10 +11,10 @@ pub mod versatest;
 
 #[must_use]
 pub fn is_supported(model: impl AsRef<str>) -> bool {
-    self::ki2600::is_2600(&model)
-        || self::ki3700::is_3700(&model)
-        || self::tti::is_tti(&model)
-        || self::versatest::is_versatest(&model)
+    self::ki2600::Instrument::model_is(&model)
+        || self::ki3700::Instrument::model_is(&model)
+        || self::tti::Instrument::model_is(&model)
+        || self::versatest::Instrument::model_is(&model)
 }
 
 impl TryFrom<Protocol> for Box<dyn Instrument> {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -9,6 +9,14 @@ pub mod ki3700;
 pub mod tti;
 pub mod versatest;
 
+#[must_use]
+pub fn is_supported(model: impl AsRef<str>) -> bool {
+    self::ki2600::is_2600(&model)
+        || self::ki3700::is_3700(&model)
+        || self::tti::is_tti(&model)
+        || self::versatest::is_versatest(&model)
+}
+
 impl TryFrom<Protocol> for Box<dyn Instrument> {
     type Error = InstrumentError;
 

--- a/src/model/tti.rs
+++ b/src/model/tti.rs
@@ -55,7 +55,7 @@ impl Instrument {
     }
 }
 
-pub(crate) fn is_tti(model: impl AsRef<str>) -> bool {
+fn is_tti(model: impl AsRef<str>) -> bool {
     [
         "2450", "2470", "DMM7510", "2460", "2461", "2461-SYS", "DMM7512", "DMM6500", "DAQ6510",
     ]

--- a/src/model/tti.rs
+++ b/src/model/tti.rs
@@ -28,7 +28,16 @@ pub struct Instrument {
 impl Instrument {
     #[must_use]
     pub fn is(info: &InstrumentInfo) -> bool {
-        info.model.as_ref().is_some_and(is_tti)
+        info.model.as_ref().is_some_and(Self::model_is)
+    }
+
+    #[must_use]
+    pub fn model_is(model: impl AsRef<str>) -> bool {
+        model
+            .as_ref()
+            .split_ascii_whitespace()
+            .last()
+            .is_some_and(is_tti)
     }
 
     #[must_use]
@@ -46,7 +55,7 @@ impl Instrument {
     }
 }
 
-fn is_tti(model: impl AsRef<str>) -> bool {
+pub(crate) fn is_tti(model: impl AsRef<str>) -> bool {
     [
         "2450", "2470", "DMM7510", "2460", "2461", "2461-SYS", "DMM7512", "DMM6500", "DAQ6510",
     ]

--- a/src/model/versatest.rs
+++ b/src/model/versatest.rs
@@ -28,7 +28,16 @@ pub struct Instrument {
 impl Instrument {
     #[must_use]
     pub fn is(info: &InstrumentInfo) -> bool {
-        info.model.as_ref().is_some_and(is_versatest)
+        info.model.as_ref().is_some_and(Self::model_is)
+    }
+
+    #[must_use]
+    pub fn model_is(model: impl AsRef<str>) -> bool {
+        model
+            .as_ref()
+            .split_ascii_whitespace()
+            .last()
+            .is_some_and(is_versatest)
     }
 
     #[must_use]
@@ -47,7 +56,7 @@ impl Instrument {
     }
 }
 
-fn is_versatest(model: impl AsRef<str>) -> bool {
+pub(crate) fn is_versatest(model: impl AsRef<str>) -> bool {
     ["MP5103", "VERSATEST-300", "VERSATEST-600", "TSPop", "TSP"].contains(&model.as_ref())
 }
 

--- a/src/model/versatest.rs
+++ b/src/model/versatest.rs
@@ -56,7 +56,7 @@ impl Instrument {
     }
 }
 
-pub(crate) fn is_versatest(model: impl AsRef<str>) -> bool {
+fn is_versatest(model: impl AsRef<str>) -> bool {
     ["MP5103", "VERSATEST-300", "VERSATEST-600", "TSPop", "TSP"].contains(&model.as_ref())
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -93,6 +93,7 @@ pub enum Protocol {
     },
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Stb {
     Stb(u16),
     NotSupported,
@@ -304,5 +305,66 @@ impl Protocol {
 impl From<Box<dyn Interface>> for Protocol {
     fn from(value: Box<dyn Interface>) -> Self {
         Self::Raw(value)
+    }
+}
+
+#[cfg(test)]
+mod unit {
+    use std::assert_matches::assert_matches;
+
+    use super::Stb;
+
+    #[test]
+    fn stb_test_mav() {
+        let input = 0x0010;
+
+        let actual = Stb::Stb(input).mav();
+
+        assert_matches!(actual, Ok(true));
+    }
+
+    #[test]
+    fn stb_test_esr() {
+        let input = 0x0020;
+
+        let actual = Stb::Stb(input).esr();
+
+        assert_matches!(actual, Ok(true));
+    }
+
+    #[test]
+    fn stb_test_srq() {
+        let input = 0x0040;
+
+        let actual = Stb::Stb(input).srq();
+
+        assert_matches!(actual, Ok(true));
+    }
+
+    #[test]
+    fn stb_test_all() {
+        for i in 0..=u16::MAX {
+            let stb = Stb::Stb(i);
+            //MAV
+            if i & 0x0010 != 0 {
+                assert_matches!(stb.mav(), Ok(true), "mav should be set - stb: {i:0>4x}");
+            } else {
+                assert_matches!(stb.mav(), Ok(false), "mav should be unset - stb: {i:0>4x}");
+            }
+
+            //ESR
+            if i & 0x0020 != 0 {
+                assert_matches!(stb.esr(), Ok(true), "esr should be set - stb: {i:0>4x}");
+            } else {
+                assert_matches!(stb.esr(), Ok(false), "esr should be unset - stb: {i:0>4x}");
+            }
+
+            //SRQ
+            if i & 0x0040 != 0 {
+                assert_matches!(stb.srq(), Ok(true), "srq should be set - stb: {i:0>4x}");
+            } else {
+                assert_matches!(stb.srq(), Ok(false), "srq should be unset - stb: {i:0>4x}");
+            }
+        }
     }
 }


### PR DESCRIPTION
* Add a new `is_supported` function that takes a model string and returns `true` is the model is supported
* Add a new `model::**::Instrument::model_is` function for each platform which takes a model string and returns true if the model is that instrument platform (e.g 2600, 3700, TTI)

**BONUS CHANGE** added tests for Stb values.