### PR TITLE
Use new `firmware.valid` Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Security -- in case of vulnerabilities.
 -->
 
+## [0.19.5]
+
+### Changed
+
+- Modify trebuchet firmware update procedure to use new command to check for validity
+
 ## [0.19.4]
 
 ### Fixed
@@ -141,7 +147,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Using `read_password` instead of `prompt_password` of rpassword crate (TSP-517)
 
 <!--Version Comparison Links-->
-[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-lib/compare/v0.19.4..HEAD
+[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-lib/compare/v0.19.5..HEAD
+[0.19.5]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.5
 [0.19.4]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.4
 [0.19.3]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.3
 [0.19.2]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsp-toolkit-kic-lib"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tsp-toolkit-kic-lib"
 description = "A library specifically enabling communication to the Keithley product-line of instruments"
-version = "0.19.4"
+version = "0.19.5"
 authors = ["Keithley Instruments, LLC"]
 edition = "2021"
 repository = "https://github.com/tektronix/tsp-toolkit-kic-lib"

--- a/src/error.rs
+++ b/src/error.rs
@@ -121,6 +121,9 @@ pub enum InstrumentError {
         source: visa_rs::Error,
     },
 
+    #[error("Instrument upgrade failed: {0}")]
+    FwUpgradeFailure(String),
+
     /// An uncategorized error.
     #[error("{0}")]
     Other(String),

--- a/src/instrument/mod.rs
+++ b/src/instrument/mod.rs
@@ -29,6 +29,39 @@ pub trait Instrument:
 {
 }
 
+#[tracing::instrument(skip(rw))]
+pub fn read_until<T: Read + Write + ?Sized>(
+    rw: &mut T,
+    one_of: Vec<String>,
+    max_attempts: usize,
+    delay_between_attempts: Duration,
+) -> Result<String> {
+    let mut accumulate = String::new();
+    for _ in 0..max_attempts {
+        std::thread::sleep(delay_between_attempts);
+        let mut buf: Vec<u8> = vec![0u8; 512];
+        match rw.read(&mut buf) {
+            Ok(_) => Ok(()),
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(delay_between_attempts);
+                continue;
+            }
+            Err(e) => Err(e),
+        }?;
+        let first_null = buf.iter().position(|&x| x == b'\0').unwrap_or(buf.len());
+        let buf = &buf[..first_null];
+        if !buf.is_empty() {
+            accumulate = format!("{accumulate}{}", String::from_utf8_lossy(buf));
+        }
+        for s in &one_of {
+            if accumulate.contains(s) {
+                return Ok(accumulate.trim().to_string());
+            }
+        }
+    }
+    Err(InstrumentError::Other(String::default()))
+}
+
 /// Read from a 'rw' until we are sure we have cleared the output queue.
 ///
 /// # Warning
@@ -49,28 +82,11 @@ pub fn clear_output_queue<T: Read + Write + ?Sized>(
     debug!("Sending print({timestamp})");
     rw.write_all(format!("print(\"{timestamp}\")\n").as_bytes())?;
 
-    let mut accumulate = String::new();
-    for _ in 0..max_attempts {
-        std::thread::sleep(delay_between_attempts);
-        let mut buf: Vec<u8> = vec![0u8; 512];
-        match rw.read(&mut buf) {
-            Ok(_) => Ok(()),
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                std::thread::sleep(delay_between_attempts);
-                continue;
-            }
-            Err(e) => Err(e),
-        }?;
-        let first_null = buf.iter().position(|&x| x == b'\0').unwrap_or(buf.len());
-        let buf = &buf[..first_null];
-        if !buf.is_empty() {
-            accumulate = format!("{accumulate}{}", String::from_utf8_lossy(buf));
-        }
-        if accumulate.contains(&timestamp) {
-            return Ok(());
-        }
+    match read_until(rw, vec![timestamp], max_attempts, delay_between_attempts) {
+        Ok(_) => Ok(()),
+        Err(InstrumentError::Other(_)) => Err(InstrumentError::Other(
+            "unable to clear instrument output queue".to_string(),
+        )),
+        Err(e) => Err(e),
     }
-    Err(InstrumentError::Other(
-        "unable to clear instrument output queue".to_string(),
-    ))
 }

--- a/src/model/versatest.rs
+++ b/src/model/versatest.rs
@@ -202,7 +202,13 @@ impl Flash for Instrument {
         } else {
             //Update Mainframe
             self.fw_flash_in_progress = true;
-            self.write_all(b"firmware.update()\n")?;
+            self.write_all(b"if firmware.valid == nil or firmware.valid == true then print('VALID') firmware.update() else print('INVALID') end\n")?;
+            let mut buf = vec![0u8; 9];
+            let _ = self.read(&mut buf)?;
+            let validity = String::from_utf8_lossy(&buf);
+            if validity.contains("INVALID") {
+                return Err(InstrumentError::Other("Unable to upgrade mainframe: Firmware was invalid".to_string()))
+            }
         }
 
         Ok(())

--- a/src/model/versatest.rs
+++ b/src/model/versatest.rs
@@ -218,7 +218,7 @@ impl Flash for Instrument {
             self.write_all(b"waitcomplete()\n")?;
             self.write_all(format!("slot.start({slot_number})\n").as_bytes())?;
             self.write_all(b"waitcomplete()\n")?;
-            match clear_output_queue(self, 60 * 5, Duration::from_secs(1)) {
+            match clear_output_queue(self, 60 * 10, Duration::from_secs(1)) {
                 Ok(()) => {}
                 Err(InstrumentError::Other(_)) => return Err(InstrumentError::FwUpgradeFailure(
                     "Upgrading module firmware took longer than 5 minutes. Check your hardware and try again."

--- a/src/model/versatest.rs
+++ b/src/model/versatest.rs
@@ -175,7 +175,7 @@ impl Flash for Instrument {
         // back.
         match clear_output_queue(self, 60 * 10, Duration::from_secs(1)) {
             Ok(()) => {}
-            Err(InstrumentError::Other(_)) => return Err(InstrumentError::Other(
+            Err(InstrumentError::Other(_)) => return Err(InstrumentError::FwUpgradeFailure(
                 "Writing image took longer than 10 minutes. Check your connection and try again."
                     .to_string(),
             )),
@@ -193,7 +193,7 @@ impl Flash for Instrument {
             self.write_all(b"waitcomplete()\n")?;
             match clear_output_queue(self, 60 * 5, Duration::from_secs(1)) {
                 Ok(()) => {}
-                Err(InstrumentError::Other(_)) => return Err(InstrumentError::Other(
+                Err(InstrumentError::Other(_)) => return Err(InstrumentError::FwUpgradeFailure(
                     "Upgrading module firmware took longer than 5 minutes. Check your hardware and try again."
                         .to_string(),
                 )),
@@ -207,7 +207,9 @@ impl Flash for Instrument {
             let _ = self.read(&mut buf)?;
             let validity = String::from_utf8_lossy(&buf);
             if validity.contains("INVALID") {
-                return Err(InstrumentError::Other("Unable to upgrade mainframe: Firmware was invalid".to_string()))
+                return Err(InstrumentError::FwUpgradeFailure(
+                    "Unable to upgrade mainframe: Firmware was invalid".to_string(),
+                ));
             }
         }
 

--- a/src/model/versatest.rs
+++ b/src/model/versatest.rs
@@ -9,7 +9,7 @@ use crate::{
         authenticate::Authentication,
         clear_output_queue,
         info::{get_info, InstrumentInfo},
-        language, Info, Login, Reset, Script,
+        language, read_until, Info, Login, Reset, Script,
     },
     interface::NonBlock,
     protocol::Protocol,
@@ -182,7 +182,34 @@ impl Flash for Instrument {
             Err(e) => return Err(e),
         }
 
-        //TODO CHECK ERRORS
+        self.write_all(b"if firmware.valid == nil or firmware.valid == true then print('VALID') else print('INVALID') end\n")?;
+        match read_until(
+            self,
+            vec!["VALID".to_string(), "INVALID".to_string()],
+            1000,
+            Duration::from_millis(1),
+        ) {
+            Ok(s) if s == "VALID" => {
+                trace!("Firwmare was valid");
+            }
+            Ok(s) if s == "INVALID" => {
+                return Err(InstrumentError::FwUpgradeFailure(
+                    "Unable to upgrade mainframe: Firmware was invalid".to_string(),
+                ));
+            }
+            Ok(_) => {
+                trace!("Firmware validity superposition detected! 😱");
+                return Err(InstrumentError::FwUpgradeFailure(
+                    "Upgrade status unknown: unable to read firmware validity".to_string(),
+                ));
+            }
+            Err(InstrumentError::Other(s)) if s == String::default() => {
+                return Err(InstrumentError::FwUpgradeFailure(
+                    "Upgrade status unknown: unable to read firmware validity".to_string(),
+                ));
+            }
+            Err(e) => return Err(e),
+        }
 
         if is_module {
             self.write_all(format!("slot[{slot_number}].firmware.update()\n").as_bytes())?;
@@ -202,15 +229,7 @@ impl Flash for Instrument {
         } else {
             //Update Mainframe
             self.fw_flash_in_progress = true;
-            self.write_all(b"if firmware.valid == nil or firmware.valid == true then print('VALID') firmware.update() else print('INVALID') end\n")?;
-            let mut buf = vec![0u8; 9];
-            let _ = self.read(&mut buf)?;
-            let validity = String::from_utf8_lossy(&buf);
-            if validity.contains("INVALID") {
-                return Err(InstrumentError::FwUpgradeFailure(
-                    "Unable to upgrade mainframe: Firmware was invalid".to_string(),
-                ));
-            }
+            self.write_all(b"firmware.update()\n")?;
         }
 
         Ok(())


### PR DESCRIPTION
Make use of the new `firmware.valid` command to check if a firmware image is valid before issuing the `firmware.update()` command.