### PR TITLE
Remove `slot.stop` and `slot.start` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Fixed -- for any bug fixes.
     Security -- in case of vulnerabilities.
 -->
+## [0.19.6]
+
+### Changed
+- No longer need to call `slot.stop` and `slot.start` since that is done by firmware now
 
 ## [0.19.5]
 
@@ -147,7 +151,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Using `read_password` instead of `prompt_password` of rpassword crate (TSP-517)
 
 <!--Version Comparison Links-->
-[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-lib/compare/v0.19.5..HEAD
+[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-lib/compare/v0.19.6..HEAD
+[0.19.6]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.6
 [0.19.5]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.5
 [0.19.4]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.4
 [0.19.3]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsp-toolkit-kic-lib"
-version = "0.19.5"
+version = "0.19.6"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tsp-toolkit-kic-lib"
 description = "A library specifically enabling communication to the Keithley product-line of instruments"
-version = "0.19.5"
+version = "0.19.6"
 authors = ["Keithley Instruments, LLC"]
 edition = "2021"
 repository = "https://github.com/tektronix/tsp-toolkit-kic-lib"

--- a/src/instrument/script.rs
+++ b/src/instrument/script.rs
@@ -21,9 +21,9 @@ where
     ///
     /// # Notes
     /// - The script name will not be validated to ensure that it is compatible with the
-    ///     scripting environment.
+    ///   scripting environment.
     /// - The given script content will only be validated by the instrument, but not
-    ///     the [`write_script`] function.
+    ///   the [`write_script`] function.
     ///
     /// # Errors
     /// Returns an [`InstrumentError`] if any errors occurred.

--- a/src/interface/async_stream.rs
+++ b/src/interface/async_stream.rs
@@ -232,7 +232,7 @@ impl Write for AsyncStream {
                     "asynchronous connection was not found".to_string(),
                 ));
             }
-        };
+        }
 
         Ok(buf.len())
     }

--- a/src/model/versatest.rs
+++ b/src/model/versatest.rs
@@ -214,10 +214,6 @@ impl Flash for Instrument {
         if is_module {
             self.write_all(format!("slot[{slot_number}].firmware.update()\n").as_bytes())?;
             self.write_all(b"waitcomplete()\n")?;
-            self.write_all(format!("slot.stop({slot_number})\n").as_bytes())?;
-            self.write_all(b"waitcomplete()\n")?;
-            self.write_all(format!("slot.start({slot_number})\n").as_bytes())?;
-            self.write_all(b"waitcomplete()\n")?;
             match clear_output_queue(self, 60 * 10, Duration::from_secs(1)) {
                 Ok(()) => {}
                 Err(InstrumentError::Other(_)) => return Err(InstrumentError::FwUpgradeFailure(

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -240,7 +240,7 @@ impl Clear for Protocol {
 
             #[cfg(feature = "visa")]
             Self::Visa { instr, .. } => instr.clear()?,
-        };
+        }
 
         Ok(())
     }


### PR DESCRIPTION
`slot.stop` and `slot.start` are now called implicitly when the fw upgrade is complete.