### PR TITLE
fix: Error out more quickly during surprise-disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
     Fixed -- for any bug fixes.
     Security -- in case of vulnerabilities.
 -->
+## [0.19.8]
+
+### Fixed
+
+- Fixed issue with not exiting quickly when LAN gets disconnected
+
 ## [0.19.7]
 
 ### Fixed
 
 - Fixed issue with missing progress indicators on TTI, 3706, and 2600 instruments
-
 
 
 ## [0.19.6]
@@ -169,7 +174,8 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - Using `read_password` instead of `prompt_password` of rpassword crate (TSP-517)
 
 <!--Version Comparison Links-->
-[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-lib/compare/v0.19.7..HEAD
+[Unreleased]: https://github.com/tektronix/tsp-toolkit-kic-lib/compare/v0.19.8..HEAD
+[0.19.8]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.8
 [0.19.7]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.7
 [0.19.6]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.6
 [0.19.5]: https://github.com/tektronix/tsp-toolkit-kic-lib/releases/tag/v0.19.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,7 +1586,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsp-toolkit-kic-lib"
-version = "0.19.7"
+version = "0.19.8"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tsp-toolkit-kic-lib"
 description = "A library specifically enabling communication to the Keithley product-line of instruments"
-version = "0.19.7"
+version = "0.19.8"
 authors = ["Keithley Instruments, LLC"]
 edition = "2021"
 repository = "https://github.com/tektronix/tsp-toolkit-kic-lib"

--- a/src/interface/async_stream.rs
+++ b/src/interface/async_stream.rs
@@ -151,7 +151,11 @@ impl TryFrom<Arc<dyn Interface + Send + Sync>> for AsyncStream {
                 if let Ok(size) = Arc::get_mut(&mut socket).unwrap().read(buf) {
                     if size == 0 {
                         error!("Connection closed: read 0 bytes");
-                        return Err(std::io::Error::new(ErrorKind::ConnectionReset, "Connection to instrument closed".to_string()).into());
+                        return Err(std::io::Error::new(
+                            ErrorKind::ConnectionReset,
+                            "Connection to instrument closed".to_string(),
+                        )
+                        .into());
                     }
 
                     let buf = &buf[..size];


### PR DESCRIPTION
When an instrument disconnects, we will read zeros from the instrument after it sends the FIN packet. This should be a signal to us that the socket should be closed. 

refs: TSP-1083